### PR TITLE
rename for clarity and rosdistro_reformat

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3806,25 +3806,15 @@ repositories:
       url: https://github.com/ros-gbp/libg2o-release.git
       version: 2018.3.25-0
     status: maintained
-  librealsense:
-    doc:
-      type: git
-      url: https://github.com/IntelRealSense/librealsense.git
-      version: legacy
-    source:
-      type: git
-      url: https://github.com/IntelRealSense/librealsense.git
-      version: legacy
-    status: maintained
   librealsense2:
     doc:
       type: git
-      url: https://github.com/IntelRealSense/realsense-ros.git
-      version: development
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: legacy
     source:
       type: git
-      url: https://github.com/IntelRealSense/realsense-ros.git
-      version: development    
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: legacy
     status: maintained
   libsick_ldmrs:
     doc:
@@ -6620,6 +6610,16 @@ repositories:
       url: https://gitlab.com/jlack/rdl.git
       version: master
     status: developed
+  realsense-ros:
+    doc:
+      type: git
+      url: https://github.com/IntelRealSense/realsense-ros.git
+      version: development
+    source:
+      type: git
+      url: https://github.com/IntelRealSense/realsense-ros.git
+      version: development
+    status: maintained
   realtime_tools:
     doc:
       type: git


### PR DESCRIPTION
rename these packages so they represent what they are and fix whitespace issues with rosdistro_reformat