### PR TITLE
rename realsense-ros to realsense2_camera in melodic distribution

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6610,7 +6610,7 @@ repositories:
       url: https://gitlab.com/jlack/rdl.git
       version: master
     status: developed
-  realsense-ros:
+  realsense2_camera:
     doc:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git


### PR DESCRIPTION
Another tiny PR based on @clalancette 's feedback on https://github.com/ros/rosdistro/pull/22938